### PR TITLE
Changing gem to require only minitest/mock so it doesn't autorun minitest

### DIFF
--- a/lib/minitest/rspec_mocks.rb
+++ b/lib/minitest/rspec_mocks.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require 'minitest/mock'
 require 'rspec/mocks'
 require_relative './rspec_mocks/version'
 

--- a/test/minitest/rspec_mocks_test.rb
+++ b/test/minitest/rspec_mocks_test.rb
@@ -1,6 +1,6 @@
 gem 'minitest'
-require_relative '../../lib/minitest/rspec_mocks'
 require "minitest/autorun"
+require_relative '../../lib/minitest/rspec_mocks'
 
 base_class = if MiniTest.const_defined?(:Unit)
                MiniTest::Unit::TestCase


### PR DESCRIPTION
Currently, requiring minitest-rspec_mocks will autorun minitest even if you are not running tests. An example I ran into is just running "bundle exec rake db:create --trace" would run minitest and pass "--trace" to minitest which doesn't understand that flag and caused the command to exit with an error.

This change fixes it so only the necessary dependency minitest/mock is loaded.